### PR TITLE
fix: preserve configured username case in plan output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve case of user names added to teams in plan output
+
 ## [0.4.0]
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,8 @@ resource "github_team" "team" {
 }
 
 locals {
-  maintainers = { for i in var.maintainers : lower(i) => "maintainer" }
-  members     = { for i in var.members : lower(i) => "member" }
+  maintainers = { for i in var.maintainers : lower(i) => { role = "maintainer", username = i } }
+  members     = { for i in var.members : lower(i) => { role = "member", username = i } }
 
   memberships = merge(local.maintainers, local.members)
 }
@@ -29,8 +29,8 @@ resource "github_team_membership" "team_membership" {
   for_each = local.memberships
 
   team_id  = github_team.team.id
-  username = each.key
-  role     = each.value
+  username = each.value.username
+  role     = each.value.role
 
   depends_on = [var.module_depends_on]
 }

--- a/test/public-repositories-with-team/variables.tf
+++ b/test/public-repositories-with-team/variables.tf
@@ -49,7 +49,7 @@ variable "members" {
   description = "A set of users that should be added to the team as members."
   type        = set(string)
   default = [
-    "terraform-test-user-1"
+    "terraform-test-USER-1"
   ]
 }
 


### PR DESCRIPTION
This is a cosmetic fix so that the case used for usernames in the config id preserved in the plan. fixes #33 