### PR TITLE
[PERMISSIONS-SUPPORT] :sparkles: Add support for maintain and triage repositories permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,24 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   The name of the team.
 
+- **`admin_repositories`**: _(Optional `set(string)`)_
+
+  A list of repository names the current team should get admin (full) permission to.
+  Default is `[]`.
+
+- **`maintain_repositories`**: _(Optional `set(string)`)_
+
+  A list of repository names the current team should get admin (maintain) permission to.
+  Default is `[]`.
+
 - **`push_repositories`**: _(Optional `set(string)`)_
 
   A list of repository names the current team should get push (read-write) permission to.
+  Default is `[]`.
+
+- **`triage_repositories`**: _(Optional `set(string)`)_
+
+  A list of repository names the current team should get push (triage) permission to.
   Default is `[]`.
 
 - **`pull_repositories`**: _(Optional `set(string)`)_
@@ -112,11 +127,6 @@ See [variables.tf] and [examples/] for details and use-cases.
 - **`members`**: _(Optional `set(string)`)_
 
   A list of users that will be added to the current team with member permissions.
-  Default is `[]`.
-
-- **`admin_repositories`**: _(Optional `set(string)`)_
-
-  A list of repository names the current team should get admin (full) permission to.
   Default is `[]`.
 
 - **`description`**: _(Optional `string`)_

--- a/main.tf
+++ b/main.tf
@@ -36,11 +36,13 @@ resource "github_team_membership" "team_membership" {
 }
 
 locals {
-  repo_admin = { for i in var.admin_repositories : lower(i) => { permission = "admin", repository = i } }
-  repo_push  = { for i in var.push_repositories : lower(i) => { permission = "push", repository = i } }
-  repo_pull  = { for i in var.pull_repositories : lower(i) => { permission = "pull", repository = i } }
+  repo_admin    = { for i in var.admin_repositories : lower(i) => { permission = "admin", repository = i } }
+  repo_maintain = { for i in var.admin_repositories : lower(i) => { permission = "maintain", repository = i } }
+  repo_push     = { for i in var.push_repositories : lower(i) => { permission = "push", repository = i } }
+  repo_triage   = { for i in var.push_repositories : lower(i) => { permission = "triage", repository = i } }
+  repo_pull     = { for i in var.pull_repositories : lower(i) => { permission = "pull", repository = i } }
 
-  repositories = merge(local.repo_admin, local.repo_push, local.repo_pull)
+  repositories = merge(local.repo_admin, local.repo_admin, local.repo_push, local.repo_triage, local.repo_pull)
 }
 
 resource "github_team_repository" "team_repository" {

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ locals {
   repo_triage   = { for i in var.push_repositories : lower(i) => { permission = "triage", repository = i } }
   repo_pull     = { for i in var.pull_repositories : lower(i) => { permission = "pull", repository = i } }
 
-  repositories = merge(local.repo_admin, local.repo_admin, local.repo_push, local.repo_triage, local.repo_pull)
+  repositories = merge(local.repo_admin, local.repo_maintain, local.repo_push, local.repo_triage, local.repo_pull)
 }
 
 resource "github_team_repository" "team_repository" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,8 +63,20 @@ variable "admin_repositories" {
   default     = []
 }
 
+variable "maintain_repositories" {
+  description = "(Optional) A list of repository names the current team should get push (maintain) permission to."
+  type        = set(string)
+  default     = []
+}
+
 variable "push_repositories" {
   description = "(Optional) A list of repository names the current team should get push (read-write) permission to."
+  type        = set(string)
+  default     = []
+}
+
+variable "triage_repositories" {
+  description = "(Optional) A list of repository names the current team should get push (triage) permission to."
   type        = set(string)
   default     = []
 }


### PR DESCRIPTION
Add support for 
* maintain_repositories
* triage_repositories

lists, to be able to give the team permissions to repositories, according to https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization
and 
https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository
