### PR TITLE
Add latest rendered terradoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 - Automatically remove maintainers from members to resolve conflicts on the fly
 - BREAKING CHANGE: Add support for `module_enabled`
 - BREAKING CHANGE: Drop support for broken terraform `1.1.0` and `1.1.1` which might corrupt terraform state.
@@ -169,13 +168,8 @@ After you've migrated the state, please run
 - This is the initial release of our terraform-github-team module that supports
   Team, Nested Team, Memberships, Team Repositories.
 
-<!-- markdown-link-check-disable -->
-
 [unreleased]: https://github.com/mineiros-io/terraform-github-team/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/mineiros-io/terraform-github-team/compare/v0.7.0...v0.8.0
-
-<!-- markdown-link-check-enable -->
-
 [0.7.0]: https://github.com/mineiros-io/terraform-github-team/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mineiros-io/terraform-github-team/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/mineiros-io/terraform-github-team/compare/v0.5.1...v0.5.2

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This module supports the following resources:
 ```hcl
 module "team" {
   source  = "mineiros-io/team/github"
-  version = "~> 0.6.0"
+  version = "~> 0.8.0"
 
   name        = "DevOps"
   description = "The DevOps Team"
@@ -144,31 +144,31 @@ See [variables.tf] and [examples/] for details and use-cases.
 
 - [**`admin_repositories`**](#var-admin_repositories): *(Optional `set(string)`)*<a name="var-admin_repositories"></a>
 
-  A list of repository names the current team should get admin (full) permission to.
+  A list of repository names the current team should get [admin](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#repository-roles-for-organizations) permission to.
 
   Default is `[]`.
 
 - [**`maintain_repositories`**](#var-maintain_repositories): *(Optional `set(string)`)*<a name="var-maintain_repositories"></a>
 
-  A list of repository names the current team should get admin (maintain) permission to.
+  A list of repository names the current team should get [maintain](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#repository-roles-for-organizations) permission to.
 
   Default is `[]`.
 
 - [**`push_repositories`**](#var-push_repositories): *(Optional `set(string)`)*<a name="var-push_repositories"></a>
 
-  A list of repository names the current team should get push (read-write) permission to.
+  A list of repository names the current team should get [push (read-write)](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#repository-roles-for-organizations) permission to.
 
   Default is `[]`.
 
 - [**`triage_repositories`**](#var-triage_repositories): *(Optional `set(string)`)*<a name="var-triage_repositories"></a>
 
-  A list of repository names the current team should get push (triage) permission to.
+  A list of repository names the current team should get [push (triage)](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#repository-roles-for-organizations) permission to.
 
   Default is `[]`.
 
 - [**`pull_repositories`**](#var-pull_repositories): *(Optional `set(string)`)*<a name="var-pull_repositories"></a>
 
-  A list of repository names the current team should get pull (read-only) permission to.
+  A list of repository names the current team should get [pull (read-only)](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#repository-roles-for-organizations) permission to.
 
   Default is `[]`.
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -62,7 +62,7 @@ section {
       ```hcl
       module "team" {
         source  = "mineiros-io/team/github"
-        version = "~> 0.6.0"
+        version = "~> 0.8.0"
 
         name        = "DevOps"
         description = "The DevOps Team"

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,17 +11,12 @@
 
 <!-- References -->
 
-<!-- markdown-link-check-disable -->
 [github-team/]: https://github.com/mineiros-io/terraform-github-team/blob/main/examples/github-team
-<!-- markdown-link-check-enable -->
-
 [homepage]: https://mineiros.io/?ref=terraform-github-team
-
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-github-team.svg?label=latest&sort=semver
-
 [releases-github]: https://github.com/mineiros-io/terraform-github-team/releases
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0

--- a/examples/github-team/README.md
+++ b/examples/github-team/README.md
@@ -75,12 +75,7 @@ Run `terraform destroy` to destroy all resources again.
 
 <!-- References -->
 
-<!-- markdown-link-check-disable -->
-
 [main.tf]: https://github.com/mineiros-io/terraform-github-team/blob/main/examples/github-team/main.tf
-
-<!-- markdown-link-check-enable -->
-
 [homepage]: https://mineiros.io/?ref=terraform-github-team
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|0.15%20|0.14%20|%200.13%20|%200.12.20+-623CE4.svg?logo=terraform


### PR DESCRIPTION
Adds the latest rendered Readme.md and corrects the version in the example. Also it seems like `v0.8.0` hasn't been released yet - this should be done after merging this PR.

- fix: use correct version in template
- docs: add latest rendered README.md
- chore: remove markdown-link-check comments
