### PR TITLE
feat: add support to use `github_team_members`

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Default is `true`.
 
+- [**`module_use_members`**](#var-module_use_members): *(Optional `bool`)*<a name="var-module_use_members"></a>
+
+  Wether to use github_team_members or github_team_membership.
+
+  Default is `false`.
+
 ## Module Outputs
 
 The following attributes are exported in the outputs of the module:
@@ -207,9 +213,13 @@ The following attributes are exported in the outputs of the module:
 
   The full team object.
 
+- [**`team_members`**](#output-team_members): *(`list(team_members)`)*<a name="output-team_members"></a>
+
+  A list of all team members (when using github_team_members).
+
 - [**`team_memberships`**](#output-team_memberships): *(`list(team_membership)`)*<a name="output-team_memberships"></a>
 
-  A list of all team memberships.
+  A list of all team memberships (when using github_team_membership).
 
 - [**`team_repositories`**](#output-team_repositories): *(`list(team_repository)`)*<a name="output-team_repositories"></a>
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -246,6 +246,14 @@ section {
           Specifies whether resources in the module will be created.
         END
       }
+
+      variable "module_use_members" {
+        type        = bool
+        default     = false
+        description = <<-END
+          Wether to use github_team_members or github_team_membership.
+        END
+      }
     }
   }
 
@@ -283,10 +291,17 @@ section {
       END
     }
 
+    output "team_members" {
+      type        = list(team_members)
+      description = <<-END
+        A list of all team members (when using github_team_members).
+      END
+    }
+
     output "team_memberships" {
       type        = list(team_membership)
       description = <<-END
-        A list of all team memberships.
+        A list of all team memberships (when using github_team_membership).
       END
     }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,8 +26,13 @@ output "team" {
   value       = one(github_team.team)
 }
 
+output "team_members" {
+  description = "A list of all team members (when using github_team_members)."
+  value       = github_team_members.team_members
+}
+
 output "team_memberships" {
-  description = "A list of all team memberships."
+  description = "A list of all team memberships (when using github_team_membership)."
   value       = github_team_membership.team_membership
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,9 @@ variable "module_depends_on" {
   description = "(Optional) A list of external resources the module depends_on. Default is []."
   default     = []
 }
+
+variable "module_use_members" {
+  type        = bool
+  description = "(Optional) Wether to use github_team_members or github_team_membership."
+  default     = false
+}


### PR DESCRIPTION
- adds support to choose between using `github_team_members` or `github_team_membership`

fix #61