### PR TITLE
[Version] github updated.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.0, < 6.0"
+      version = ">= 4.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
### Summary
The Github provider version cap has been bumped to allow for the latest version. All resource definitions are compatible with v6.